### PR TITLE
upgrade sucker_punch backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
+*.iml
 .bundle
+.idea
 Gemfile.lock
 pkg/*
 vendor/*

--- a/lib/backgrounder/support/backends.rb
+++ b/lib/backgrounder/support/backends.rb
@@ -61,7 +61,7 @@ module CarrierWave
           end
 
           def enqueue_sucker_punch(worker, *args)
-            worker.new.async.perform(*args)
+            worker.perform_async(*args)
           end
 
           def enqueue_qu(worker, *args)

--- a/lib/backgrounder/version.rb
+++ b/lib/backgrounder/version.rb
@@ -1,5 +1,5 @@
 module CarrierWave
   module Backgrounder
-    VERSION = "0.4.2"
+    VERSION = '1.0.0'
   end
 end


### PR DESCRIPTION
as stated in https://github.com/brandonhilkert/sucker_punch#backwards-compatibility, the new syntax is `LogJob.perform_async(...)`. incremented major version to note this breaking change.

do **NOT** merge, need test coverage. note to self for upstream PR.
